### PR TITLE
refactor: Remove axios and replace with fetch

### DIFF
--- a/__mocks__/got.ts
+++ b/__mocks__/got.ts
@@ -1,0 +1,5 @@
+// __mocks__/got.ts
+export default {
+  get: jest.fn(),
+  post: jest.fn(),
+};

--- a/__mocks__/krb-smart-api-module.ts
+++ b/__mocks__/krb-smart-api-module.ts
@@ -1,0 +1,2 @@
+// __mocks__/krb-smart-api-module.ts
+export default {};

--- a/__mocks__/public-ip.ts
+++ b/__mocks__/public-ip.ts
@@ -1,0 +1,5 @@
+// __mocks__/public-ip.ts
+export default {
+  v4: jest.fn().mockResolvedValue('127.0.0.1'),
+  v6: jest.fn().mockResolvedValue('::1'),
+};

--- a/__mocks__/smartapi-javascript.ts
+++ b/__mocks__/smartapi-javascript.ts
@@ -1,0 +1,4 @@
+// __mocks__/smartapi-javascript.ts
+export default {
+  SmartAPI: jest.fn(),
+};

--- a/__tests__/helpers/api.test.ts
+++ b/__tests__/helpers/api.test.ts
@@ -1,0 +1,84 @@
+import { get, post } from '../../src/helpers/api';
+
+global.fetch = jest.fn();
+
+describe('api', () => {
+  beforeEach(() => {
+    (fetch as jest.Mock).mockClear();
+  });
+
+  describe('get', () => {
+    it('should make a GET request and return JSON data', async () => {
+      const mockData = { message: 'Success' };
+      (fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ 'Content-Type': 'application/json' }),
+        json: async () => mockData,
+      });
+
+      const data = await get('https://example.com/data', {});
+      expect(fetch).toHaveBeenCalledWith('https://example.com/data', {
+        method: 'GET',
+        headers: {},
+      });
+      expect(data).toEqual(mockData);
+    });
+
+    it('should make a GET request and return text data', async () => {
+      const mockData = 'Success';
+      (fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ 'Content-Type': 'text/plain' }),
+        text: async () => mockData,
+      });
+
+      const data = await get('https://example.com/data', {});
+      expect(fetch).toHaveBeenCalledWith('https://example.com/data', {
+        method: 'GET',
+        headers: {},
+      });
+      expect(data).toEqual(mockData);
+    });
+
+    it('should throw an error if the request fails', async () => {
+      (fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: async () => 'Internal Server Error',
+      });
+
+      await expect(get('https://example.com/data', {})).rejects.toThrow('Internal Server Error');
+    });
+  });
+
+  describe('post', () => {
+    it('should make a POST request and return JSON data', async () => {
+      const mockData = { message: 'Success' };
+      const requestBody = { key: 'value' };
+      (fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ 'Content-Type': 'application/json' }),
+        json: async () => mockData,
+      });
+
+      const data = await post('https://example.com/data', requestBody, {});
+      expect(fetch).toHaveBeenCalledWith('https://example.com/data', {
+        method: 'POST',
+        headers: {},
+        body: JSON.stringify(requestBody),
+      });
+      expect(data).toEqual(mockData);
+    });
+
+    it('should throw an error if the request fails', async () => {
+      const requestBody = { key: 'value' };
+      (fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        text: async () => 'Bad Request',
+      });
+
+      await expect(post('https://example.com/data', requestBody, {})).rejects.toThrow('Bad Request');
+    });
+  });
+});

--- a/__tests__/helpers/apiService.test.ts
+++ b/__tests__/helpers/apiService.test.ts
@@ -1,6 +1,6 @@
 import { getLtpData, searchScrip, fetchData } from '../../src/helpers/apiService';
 import * as api from '../../src/helpers/api';
-import * as krb from 'krb-smart-api-module';
+import { getSmartSession } from 'krb-smart-api-module';
 import DataStore from '../../src/store/dataStore';
 import ScripMasterStore from '../../src/store/scripMasterStore';
 import { GET_LTP_DATA_API, SEARCHSCRIPAPI, SCRIPMASTER } from '../../src/helpers/constants';
@@ -10,7 +10,9 @@ jest.mock('krb-smart-api-module');
 jest.mock('../../src/store/dataStore');
 jest.mock('../../src/store/orderStore');
 jest.mock('../../src/store/scripMasterStore');
-
+jest.mock('krb-smart-api-module', () => ({
+  getSmartSession: jest.fn(),   // 👈 ensure it’s a mock
+}));
 describe('apiService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -18,7 +20,7 @@ describe('apiService', () => {
 
   describe('getLtpData', () => {
     it('should fetch LTP data successfully', async () => {
-      (krb.getSmartSession as jest.Mock).mockResolvedValue({ jwtToken: 'test_token' });
+      (getSmartSession as jest.Mock).mockResolvedValue({ jwtToken: 'test_token' });
       const getPostDataMock = jest.fn().mockReturnValue({ APIKEY: 'test_api_key' });
       (DataStore.getInstance as jest.Mock).mockReturnValue({
         getPostData: getPostDataMock,
@@ -45,7 +47,7 @@ describe('apiService', () => {
 
   describe('searchScrip', () => {
     it('should search for a scrip successfully', async () => {
-      (krb.getSmartSession as jest.Mock).mockResolvedValue({ jwtToken: 'test_token' });
+      (getSmartSession as jest.Mock).mockResolvedValue({ jwtToken: 'test_token' });
       const getPostDataMock = jest.fn().mockReturnValue({ APIKEY: 'test_api_key' });
       (DataStore.getInstance as jest.Mock).mockReturnValue({
         getPostData: getPostDataMock,

--- a/__tests__/helpers/apiService.test.ts
+++ b/__tests__/helpers/apiService.test.ts
@@ -1,0 +1,100 @@
+import { getLtpData, searchScrip, fetchData } from '../../src/helpers/apiService';
+import * as api from '../../src/helpers/api';
+import * as krb from 'krb-smart-api-module';
+import DataStore from '../../src/store/dataStore';
+import ScripMasterStore from '../../src/store/scripMasterStore';
+import { GET_LTP_DATA_API, SEARCHSCRIPAPI, SCRIPMASTER } from '../../src/helpers/constants';
+
+jest.mock('../../src/helpers/api');
+jest.mock('krb-smart-api-module');
+jest.mock('../../src/store/dataStore');
+jest.mock('../../src/store/orderStore');
+jest.mock('../../src/store/scripMasterStore');
+
+describe('apiService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getLtpData', () => {
+    it('should fetch LTP data successfully', async () => {
+      (krb.getSmartSession as jest.Mock).mockResolvedValue({ jwtToken: 'test_token' });
+      const getPostDataMock = jest.fn().mockReturnValue({ APIKEY: 'test_api_key' });
+      (DataStore.getInstance as jest.Mock).mockReturnValue({
+        getPostData: getPostDataMock,
+      });
+      (api.post as jest.Mock).mockResolvedValue({ data: { ltp: 100 } });
+
+      const result = await getLtpData({
+        exchange: 'NFO',
+        tradingsymbol: 'NIFTY',
+        symboltoken: '12345',
+      });
+
+      expect(api.post).toHaveBeenCalledWith(
+        GET_LTP_DATA_API,
+        { exchange: 'NFO', tradingsymbol: 'NIFTY', symboltoken: '12345' },
+        expect.objectContaining({
+          Authorization: 'Bearer test_token',
+          'X-PrivateKey': 'test_api_key',
+        })
+      );
+      expect(result).toEqual({ ltp: 100 });
+    });
+  });
+
+  describe('searchScrip', () => {
+    it('should search for a scrip successfully', async () => {
+      (krb.getSmartSession as jest.Mock).mockResolvedValue({ jwtToken: 'test_token' });
+      const getPostDataMock = jest.fn().mockReturnValue({ APIKEY: 'test_api_key' });
+      (DataStore.getInstance as jest.Mock).mockReturnValue({
+        getPostData: getPostDataMock,
+      });
+      (api.post as jest.Mock).mockResolvedValue({ data: { scrip: 'test_scrip' } });
+
+      const result = await searchScrip('NIFTY');
+
+      expect(api.post).toHaveBeenCalledWith(
+        SEARCHSCRIPAPI,
+        { exchange: 'NFO', searchscrip: 'NIFTY' },
+        expect.objectContaining({
+          Authorization: 'Bearer test_token',
+          'X-PrivateKey': 'test_api_key',
+        })
+      );
+      expect(result).toEqual({ scrip: 'test_scrip' });
+    });
+  });
+
+  describe('fetchData', () => {
+    it('should fetch scrip master data from API if not in store', async () => {
+      const getPostDataMock = jest.fn().mockReturnValue({ SCRIP_MASTER_JSON: [] });
+      const setPostDataMock = jest.fn();
+      (ScripMasterStore.getInstance as jest.Mock).mockReturnValue({
+        getPostData: getPostDataMock,
+        setPostData: setPostDataMock,
+      });
+      const mockScripMaster = [{ name: 'NIFTY' }];
+      (api.get as jest.Mock).mockResolvedValue(mockScripMaster);
+
+      const result = await fetchData();
+
+      expect(api.get).toHaveBeenCalledWith(SCRIPMASTER, {});
+      expect(setPostDataMock).toHaveBeenCalledWith({ SCRIP_MASTER_JSON: mockScripMaster });
+      expect(result).toEqual(mockScripMaster);
+    });
+
+    it('should return scrip master data from store if available', async () => {
+      const mockScripMaster = [{ name: 'NIFTY' }];
+      const getPostDataMock = jest.fn().mockReturnValue({ SCRIP_MASTER_JSON: mockScripMaster });
+      (ScripMasterStore.getInstance as jest.Mock).mockReturnValue({
+        getPostData: getPostDataMock,
+      });
+
+      const result = await fetchData();
+
+      expect(api.get).not.toHaveBeenCalled();
+      expect(result).toEqual(mockScripMaster);
+    });
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,25 @@
-module.exports = {
-  preset: 'ts-jest',
+// jest.config.js
+export default {
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', {}],
+  },
+
+  transformIgnorePatterns: [
+    '/node_modules/(?!got|public-ip|@sindresorhus/.*|krb-smart-api-module|smartapi-javascript)/',
+  ],
+  extensionsToTreatAsEsm: ['.ts'],
+  globals: {
+    'ts-jest': {
+      useESM: true,
+      tsconfig: 'tsconfig.jest.json',
+    },
+  },
+  moduleNameMapper: {
+    '^got$': '<rootDir>/__mocks__/got.ts',
+    '^public-ip$': '<rootDir>/__mocks__/public-ip.ts',
+    '^smartapi-javascript$': '<rootDir>/__mocks__/smartapi-javascript.ts',
+    '^krb-smart-api-module$': '<rootDir>/__mocks__/krb-smart-api-module.ts',
+  },
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "axios": "^1.4.0",
     "body-parser": "^1.20.0",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
@@ -18,7 +17,6 @@
     "@babel/preset-flow": "^7.22.5",
     "@babel/preset-typescript": "^7.22.5",
     "@eslint/js": "^9.0.0",
-    "@types/axios": "^0.14.0",
     "@types/cors": "^2.8.12",
     "@types/dotenv": "^8.2.0",
     "@types/express": "^4.17.17",

--- a/src/helpers/api.ts
+++ b/src/helpers/api.ts
@@ -1,4 +1,3 @@
-import { get as _get } from 'lodash';
 import { ALGO } from './constants';
 
 const handleResponse = async (response: Response) => {

--- a/src/helpers/api.ts
+++ b/src/helpers/api.ts
@@ -1,0 +1,32 @@
+import { get as _get } from 'lodash';
+import { ALGO } from './constants';
+
+const handleResponse = async (response: Response) => {
+  if (!response.ok) {
+    const error = await response.text();
+    console.log(`${ALGO}: API request failed with status ${response.status} and message ${error}`);
+    throw new Error(error);
+  }
+  const contentType = response.headers.get('content-type');
+  if (contentType && contentType.indexOf('application/json') !== -1) {
+    return response.json();
+  }
+  return response.text();
+};
+
+export const post = async (url: string, data: any, headers: any) => {
+  const response = await fetch(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(data),
+  });
+  return handleResponse(response);
+};
+
+export const get = async (url: string, headers: any) => {
+  const response = await fetch(url, {
+    method: 'GET',
+    headers,
+  });
+  return handleResponse(response);
+};

--- a/src/helpers/apiService.ts
+++ b/src/helpers/apiService.ts
@@ -23,7 +23,6 @@ import {
   hedgeCalculation,
   isMarketClosed,
 } from './functions';
-import { Response } from 'express';
 import {
   BothPresent,
   CheckOptionType,
@@ -83,7 +82,7 @@ export const getLtpWithRetry = async ({
   while (attempt < maxRetries) {
     const ltpData: LtpDataType = await getLtpData({ exchange, symboltoken, tradingsymbol });
 
-    if (ltpData && ltpData.ltp && ltpData.ltp > 0) {
+    if (ltpData?.ltp > 0) {
       return ltpData;
     }
 
@@ -525,68 +524,7 @@ const repeatShortStraddle = async (difference: number, atmStrike: number) => {
     throw error;
   }
 };
-// const getPositionByToken = ({ positions, token }: getPositionByTokenType) => {
-//   for (const position of positions) {
-//     if (position.symboltoken === token) {
-//       return position;
-//     }
-//   }
-//   return null;
-// };
-// const findTradeByStrike = async (tradeStrike: number) => {
-//   const positions = await getPositionsJson();
-//   for (const position of positions) {
-//     const strike = parseInt(position.strikeprice);
-//     if (strike === tradeStrike) return position;
-//   }
-//   return null;
-// };
-// const shouldCloseTrade = async ({ ltp, avg, trade }: shouldCloseTradeType) => {
-//   const thresholdPrice = avg * 3;
-//   const hasPriceCrossedThreshold = parseInt(trade.netqty) < 0 && ltp >= thresholdPrice;
-//   const isLtpBelowOne = parseInt(trade.netqty) < 0 && ltp < 1;
-//   console.log(
-//     `${ALGO}: checking shouldCloseTrade, trade strike: ${trade.strikeprice}, trade option type: ${trade.optiontype}, ltp: ${ltp}, thresholdPrice: ${thresholdPrice}`
-//   );
-//   if (hasPriceCrossedThreshold || isLtpBelowOne) {
-//     console.log(`${ALGO}: Yes, close this particular trade with strike price ${trade.strikeprice}`);
-//     try {
-//       await closeParticularTrade({ trade });
-//     } catch (error) {
-//       console.log(`${ALGO}: closeParticularTrade could not be called`);
-//       throw error;
-//     }
-//   }
-// };
-// const checkPositionToClose = async ({ openPositions }: checkPositionToCloseType) => {
-//   console.log(`${ALGO}: checkPositionToClose`);
-//   try {
-//     for (const position of openPositions) {
-//       if (
-//         position &&
-//         position.exchange === 'NFO' &&
-//         position.tradingsymbol &&
-//         position.sellavgprice &&
-//         parseInt(position.netqty) < 0
-//       ) {
-//         const currentLtpPrice = getPositionByToken({
-//           positions: openPositions,
-//           token: position.symboltoken,
-//         })?.ltp;
-//         await shouldCloseTrade({
-//           ltp: typeof currentLtpPrice === 'string' ? parseFloat(currentLtpPrice) : 0,
-//           avg: parseFloat(position.sellavgprice),
-//           trade: position,
-//         });
-//       }
-//     }
-//   } catch (error) {
-//     const errorMessage = `${ALGO}: checkPositionToClose failed error below`;
-//     console.log(errorMessage);
-//     console.log(error);
-//     throw error;
-//   }
-// };
+
 /**
  * Fetches the open positions.
  * @param {boolean} [isAbrupt=false] - Whether to fetch all open positions or only sell positions.
@@ -776,26 +714,18 @@ const executeTrade = async () => {
   let resp: number | string = `${ALGO}: Trade Closed`;
   const closingTime: TimeComparisonType = { hours: 15, minutes: 17 };
   const isPastClosingTime = isCurrentTimeGreater(closingTime);
-  //const isPastClosingTime = false; //HARDCODED FOR TESTING
-  // const marginDetails = await getMarginDetails();
-  // console.log(`${ALGO}: marginDetails: `, marginDetails);
-  // const quantity = OrderStore.getInstance().getPostData().QUANTITY;
-  // const lossPerLot = OrderStore.getInstance().getPostData().LOSSPERLOT;
   const calculatedFixStopLoss = 12000;
   console.log(`${ALGO}: calculatedFixStopLoss: ${calculatedFixStopLoss}`);
   const mtmData = await getMtm();
   console.log(`${ALGO}: MTM: ${mtmData} -----`);
-  // let isStoplossExceeded = Math.abs(mtmData) > calculatedFixStopLoss;
   const isStoplossExceeded = false;
   console.log(`${ALGO}: isStoplossExceeded: ${isStoplossExceeded}`);
   console.log(`${ALGO}: isPastClosingTime: ${isPastClosingTime}`);
   const data = await getPositionsJson();
-  //await checkPositionToClose({ openPositions: data });
   if (isPastClosingTime === false && isStoplossExceeded === false) {
     await coreTradeExecution({ data });
     resp = mtmData;
   }
-  // if (isStoplossExceeded && getAllOpenPositions(data).length > 0) await closeTrade(true);
   if (isPastClosingTime && getOpenSellPositions(data).length > 0) await closeTrade(false);
   return resp;
 };
@@ -824,7 +754,7 @@ const isTradeAllowed = async (indiaVix: number) => {
     await delay({ milliSeconds: DELAY });
     isSmartAPIWorking = !isEmpty(smartData);
   } catch (err) {
-    console.log('Error occurred for generateSmartSession');
+    console.log('Error occurred for generateSmartSession:', err);
   }
   console.log(
     `${ALGO}: checking conditions, isWeekend: ${isWeekend}, is indiaVix > 15: ${indiaVix}, isHoliday: ${isHoliday}, isMarketOpen: ${isMarketOpen}, hasTimePassed 09:45am: ${hasTimePassedToTakeTrade}, isSmartAPIWorking: ${isSmartAPIWorking}`
@@ -846,9 +776,6 @@ const isTradeAllowed = async (indiaVix: number) => {
  * @returns {Promise<any>} A promise that resolves with the result of the trade execution.
  */
 export const checkMarketConditionsAndExecuteTrade = async (lots: number = LOTS, lossPerLot: number = LOSSPERLOT) => {
-  //let expiryDate = '30MAY2024'; //HARDCODED FOR TESTING
-  //const orderBook = await getOrderBook();
-  //console.log(orderBook);
   const expiryDate = getTodayExpiry();
   const indiaVix = await getIndexScrip({ scriptName: 'INDIA VIX' });
   await delay({ milliSeconds: DELAY });
@@ -871,8 +798,6 @@ export const checkMarketConditionsAndExecuteTrade = async (lots: number = LOTS, 
   });
   console.log(`${ALGO}: OrderStore data: `, OrderStore.getInstance().getPostData());
   try {
-    // await isTradeAllowed(); //HARDCODED FOR TESTING
-    // return await executeTrade(); //HARDCODED FOR TESTING
     const isAllowed = await isTradeAllowed(indiaVixLtp.ltp);
     if (isAllowed === false) return MESSAGE_NOT_TAKE_TRADE;
     else return await executeTrade();

--- a/src/helpers/apiService.ts
+++ b/src/helpers/apiService.ts
@@ -1,6 +1,4 @@
 import { get as _get, isArray, isEmpty } from 'lodash';
-// eslint-disable-next-line
-const axios = require('axios');
 import {
   DELAY,
   delay,
@@ -62,10 +60,10 @@ import {
   TRANSACTION_TYPE_SELL,
 } from './constants';
 import DataStore from '../store/dataStore';
-
 import OrderStore from '../store/orderStore';
 import ScripMasterStore from '../store/scripMasterStore';
 import moment from 'moment-timezone';
+import { get, post } from './api';
 
 export const getLtpWithRetry = async ({
   exchange,
@@ -105,27 +103,22 @@ export const getLtpWithRetry = async ({
 export const getLtpData = async ({ exchange, tradingsymbol, symboltoken }: getLtpDataType): Promise<LtpDataType> => {
   const smartApiData: ISmartApiData = await getSmartSession();
   const jwtToken = _get(smartApiData, 'jwtToken');
-  const data = JSON.stringify({ exchange, tradingsymbol, symboltoken });
+  const data = { exchange, tradingsymbol, symboltoken };
   const cred = DataStore.getInstance().getPostData();
-  const config = {
-    method: 'post',
-    url: GET_LTP_DATA_API,
-    headers: {
-      Authorization: `Bearer ${jwtToken}`,
-      'Content-Type': 'application/json',
-      Accept: 'application/json',
-      'X-UserType': 'USER',
-      'X-SourceID': 'WEB',
-      'X-ClientLocalIP': 'CLIENT_LOCAL_IP',
-      'X-ClientPublicIP': 'CLIENT_PUBLIC_IP',
-      'X-MACAddress': 'MAC_ADDRESS',
-      'X-PrivateKey': cred.APIKEY,
-    },
-    data: data,
+  const headers = {
+    Authorization: `Bearer ${jwtToken}`,
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+    'X-UserType': 'USER',
+    'X-SourceID': 'WEB',
+    'X-ClientLocalIP': 'CLIENT_LOCAL_IP',
+    'X-ClientPublicIP': 'CLIENT_PUBLIC_IP',
+    'X-MACAddress': 'MAC_ADDRESS',
+    'X-PrivateKey': cred.APIKEY,
   };
   try {
-    const response = await axios(config);
-    return _get(response, 'data.data', {}) || {};
+    const response = await post(GET_LTP_DATA_API, data, headers);
+    return _get(response, 'data', {}) || {};
   } catch (error) {
     console.log(`${ALGO}: the GET_LTP_DATA_API failed error below`);
     console.log(error);
@@ -141,25 +134,20 @@ export const searchScrip = async (scripName: string) => {
   const smartApiData: ISmartApiData = await getSmartSession();
   const jwtToken = _get(smartApiData, 'jwtToken');
   const cred = DataStore.getInstance().getPostData();
-  const config = {
-    method: 'post',
-    url: SEARCHSCRIPAPI,
-    headers: {
-      Authorization: `Bearer ${jwtToken}`,
-      'Content-Type': 'application/json',
-      Accept: 'application/json',
-      'X-UserType': 'USER',
-      'X-SourceID': 'WEB',
-      'X-ClientLocalIP': 'CLIENT_LOCAL_IP',
-      'X-ClientPublicIP': 'CLIENT_PUBLIC_IP',
-      'X-MACAddress': 'MAC_ADDRESS',
-      'X-PrivateKey': cred.APIKEY,
-    },
-    data: { exchange: 'NFO', searchscrip: scripName },
+  const headers = {
+    Authorization: `Bearer ${jwtToken}`,
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+    'X-UserType': 'USER',
+    'X-SourceID': 'WEB',
+    'X-ClientLocalIP': 'CLIENT_LOCAL_IP',
+    'X-ClientPublicIP': 'CLIENT_PUBLIC_IP',
+    'X-MACAddress': 'MAC_ADDRESS',
+    'X-PrivateKey': cred.APIKEY,
   };
-  return await axios(config).then((response: object) => {
-    return _get(response, 'data.data', '');
-  });
+  const data = { exchange: 'NFO', searchscrip: scripName };
+  const response = await post(SEARCHSCRIPAPI, data, headers);
+  return _get(response, 'data', '');
 };
 /**
  * Fetches the scrip master data.
@@ -171,21 +159,19 @@ export const fetchData = async (): Promise<scripMasterResponse[]> => {
   if (data.length > 0) {
     return data as scripMasterResponse[];
   } else {
-    return await axios
-      .get(SCRIPMASTER)
-      .then((response: object) => {
-        const acData: scripMasterResponse[] = _get(response, 'data', []) || [];
-        console.log(`${ALGO}: response if script master api loaded and its length is ${acData.length}`);
-        ScripMasterStore.getInstance().setPostData({
-          SCRIP_MASTER_JSON: acData,
-        });
-        return acData;
-      })
-      .catch((evt: object) => {
-        console.log(`${ALGO}: fetchData failed error below`);
-        console.log(evt);
-        throw evt;
+    try {
+      const response = (await get(SCRIPMASTER, {})) as scripMasterResponse[];
+      const acData: scripMasterResponse[] = response;
+      console.log(`${ALGO}: response if script master api loaded and its length is ${acData.length}`);
+      ScripMasterStore.getInstance().setPostData({
+        SCRIP_MASTER_JSON: acData,
       });
+      return acData;
+    } catch (evt) {
+      console.log(`${ALGO}: fetchData failed error below`);
+      console.log(evt);
+      throw evt;
+    }
   }
 };
 /**
@@ -284,7 +270,7 @@ const doOrder = async ({
   const lotsCalc = isHedge ? hedgeQuantity : lots;
   console.log(`${ALGO} {doOrderByStrike}: isHedge: ${isHedge}, lotsCalc: ${lotsCalc}, hedgeQuantity: ${hedgeQuantity}`);
   const quantity = Math.abs(lotSize * lotsCalc);
-  const data = JSON.stringify({
+  const data = {
     exchange: 'NFO',
     tradingsymbol,
     symboltoken,
@@ -297,37 +283,29 @@ const doOrder = async ({
     duration: 'DAY',
     price,
     triggerprice,
-  });
+  };
   console.log(`${ALGO} doOrder data `, data);
   const cred = DataStore.getInstance().getPostData();
-  const config = {
-    method: 'post',
-    url: ORDER_API,
-    headers: {
-      Authorization: `Bearer ${jwtToken}`,
-      'Content-Type': 'application/json',
-      Accept: 'application/json',
-      'X-UserType': 'USER',
-      'X-SourceID': 'WEB',
-      'X-ClientLocalIP': 'CLIENT_LOCAL_IP',
-      'X-ClientPublicIP': 'CLIENT_PUBLIC_IP',
-      'X-MACAddress': 'MAC_ADDRESS',
-      'X-PrivateKey': cred.APIKEY,
-    },
-    data: data,
+  const headers = {
+    Authorization: `Bearer ${jwtToken}`,
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+    'X-UserType': 'USER',
+    'X-SourceID': 'WEB',
+    'X-ClientLocalIP': 'CLIENT_LOCAL_IP',
+    'X-ClientPublicIP': 'CLIENT_PUBLIC_IP',
+    'X-MACAddress': 'MAC_ADDRESS',
+    'X-PrivateKey': cred.APIKEY,
   };
-  return axios(config)
-    .then((response: Response) => {
-      const resData = _get(response, 'data');
-      //console.log(`${ALGO}: order response `, resData);
-      return resData;
-    })
-    .catch(function (error: Response) {
-      const errorMessage = `${ALGO}: doOrder failed error below`;
-      console.log(errorMessage);
-      console.log(error);
-      throw error;
-    });
+  try {
+    const response = await post(ORDER_API, data, headers);
+    return response;
+  } catch (error) {
+    const errorMessage = `${ALGO}: doOrder failed error below`;
+    console.log(errorMessage);
+    console.log(error);
+    throw error;
+  }
 };
 /**
  * Places an order by strike price.


### PR DESCRIPTION
- Replaced all usages of axios with the native fetch API.
- Created a new `api.ts` module to encapsulate all fetch calls.
- Refactored `apiService.ts` to use the new `api.ts` module.
- Added Jest tests for the new `api.ts` module and the refactored `apiService.ts`.
- Removed axios and @types/axios from package.json.
- Configured Jest to handle ES Modules from dependencies.
- Fixed test suite mocking for `krb-smart-api-module`.