### PR TITLE
feat: add oracle cloud deployment and rename status command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,48 @@
+name: Deploy to Oracle Cloud
+
+on:
+  push:
+    branches:
+      - development
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy using ssh
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.ORACLE_HOST }}
+          username: ${{ secrets.ORACLE_USER }}
+          key: ${{ secrets.ORACLE_SSH_KEY }}
+          script: |
+            # Check if directory exists, if not clone it
+            if [ ! -d "~/smart-api" ]; then
+              git clone https://github.com/kunalrbhatia/smart-api.git ~/smart-api
+            fi
+            
+            cd ~/smart-api
+            git fetch origin development
+            git reset --hard origin/development
+            
+            # Install pnpm if not present
+            if ! command -v pnpm &> /dev/null; then
+                sudo npm install -g pnpm
+            fi
+            
+            pnpm install --frozen-lockfile
+            pnpm build
+            
+            # Create/Update .env file from secrets
+            echo "PORT=${{ secrets.PORT || 3000 }}" > .env
+            echo "NODE_ENV=production" >> .env
+            echo "API_KEY=${{ secrets.API_KEY }}" >> .env
+            echo "CLIENT_CODE=${{ secrets.CLIENT_CODE }}" >> .env
+            echo "CLIENT_PIN=${{ secrets.CLIENT_PIN }}" >> .env
+            echo "CLIENT_TOTP_PIN=${{ secrets.CLIENT_TOTP_PIN }}" >> .env
+            echo "TELEGRAM_BOT_TOKEN=${{ secrets.TELEGRAM_BOT_TOKEN }}" >> .env
+            echo "TELEGRAM_CHAT_ID=${{ secrets.TELEGRAM_CHAT_ID }}" >> .env
+            
+            # Restart with PM2
+            pm2 restart ecosystem.config.cjs || pm2 start ecosystem.config.cjs
+            pm2 save

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,5 @@ node_modules/
 coverage/
 *.log
 package.json
+README.md
+.github/workflows/deploy.yml

--- a/README.md
+++ b/README.md
@@ -109,6 +109,36 @@ The bot includes a built-in Telegram listener for remote monitoring and control.
 
 ---
 
+## 🚀 Deployment
+
+The project is configured for automated deployment to **Oracle Cloud** via GitHub Actions.
+
+### Automated Workflow
+The [deploy.yml](.github/workflows/deploy.yml) workflow triggers on every push to the `development` branch. It performs the following on the target server:
+1. Pulls the latest code.
+2. Installs dependencies using `pnpm`.
+3. Builds the project (`babel` transpilation).
+4. Generates the `.env` file from GitHub Secrets.
+5. Restarts the application using **PM2** via `ecosystem.config.cjs`.
+
+### Required GitHub Secrets
+To use the deployment workflow, add the following secrets in your repository settings (**Settings > Secrets and variables > Actions**):
+
+| Secret Name | Description |
+|-------------|-------------|
+| `ORACLE_HOST` | Public IP of your Oracle Cloud instance. |
+| `ORACLE_USER` | SSH username (e.g., `ubuntu`). |
+| `ORACLE_SSH_KEY` | Your private SSH key (`.key` or `.pem` content). |
+| `PORT` | The port the app should run on (default: `3000`). |
+| `API_KEY` | Your SmartAPI Key. |
+| `CLIENT_CODE` | Your SmartAPI Client Code. |
+| `CLIENT_PIN` | Your SmartAPI Client Pin. |
+| `CLIENT_TOTP_PIN` | Your 16-character TOTP Secret Key. |
+| `TELEGRAM_BOT_TOKEN` | Your Telegram Bot Token. |
+| `TELEGRAM_CHAT_ID` | Your Telegram Chat ID. |
+
+---
+
 ## 📂 Project Structure
 
 ```

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -1,0 +1,16 @@
+module.exports = {
+  apps: [
+    {
+      name: 'smart-api',
+      script: 'dist/server.js',
+      instances: 1,
+      autorestart: true,
+      watch: false,
+      max_memory_restart: '1G',
+      env: {
+        NODE_ENV: 'production',
+        PORT: 3000,
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## Description
This PR adds an automated deployment workflow to **Oracle Cloud** and renames the Telegram status command to avoid conflicts.

### Changes:
- **Telegram Commands**: Renamed \/status\ to \/status-smart-api\ to prevent conflicts with other bots.
- **GitHub Workflow**: Added \.github/workflows/deploy.yml\ which automates SSH-based deployment to your Oracle server.
- **PM2 Configuration**: Added \ecosystem.config.cjs\ to manage the application process with PM2 in production.
- **Documentation**: Updated \README.md\ with a new **Deployment** section and the updated command list.
- **Formatting**: Updated \.prettierignore\ to exclude \README.md\ and \deploy.yml\.

### Setup Instructions:
To enable automated deployments, add the following secrets to your GitHub repository (**Settings > Secrets and variables > Actions**):
- \ORACLE_HOST\, \ORACLE_USER\, \ORACLE_SSH_KEY\ (For SSH access)
- \API_KEY\, \CLIENT_CODE\, \CLIENT_PIN\, \CLIENT_TOTP_PIN\, \TELEGRAM_BOT_TOKEN\, \TELEGRAM_CHAT_ID\ (App credentials)

### Verification:
Ran the full suite locally:
\\\powershell
pnpm format; pnpm lint; pnpm typecheck; pnpm test; pnpm build
\\\
Status: ✅ All 206 tests passed.