### PR TITLE
chore: standardize .env ignore and template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,9 @@ NODE_ENV=development
 API_KEY=
 CLIENT_CODE=
 CLIENT_PIN=
-CLIENT_TOTP_PIN= # Your 16-character TOTP secret key provided by Angel Broking
+CLIENT_TOTP_PIN=
+# Your TOTP secret key provided by Angel Broking (e.g., 16 or 26 characters)
 
-# Telegram configuration
+# Telegram notifications
 TELEGRAM_BOT_TOKEN=
 TELEGRAM_CHAT_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@
 /smart_api_client
 /target
 /dist
-.env
+.env*
+!.env.example
 *.log
 coverage
 pnpm-workspace.yaml


### PR DESCRIPTION
## Description
This PR improves the environment configuration setup by:
1. Updating .gitignore to ignore all .env* files to prevent accidental leakage of sensitive credentials.
2. Explicitly allowing .env.example in .gitignore so it remains tracked.
3. Syncing .env.example with the latest structure of .env, ensuring all necessary keys are present as placeholders.

## Changes
- Modified .gitignore
- Updated .env.example

## Verification
- Ran full verification suite: pnpm format; pnpm lint; pnpm typecheck; pnpm test; pnpm build.
- All tests passed and build successful.