### PR TITLE
feat: ensure scrip master is redownloaded daily

### DIFF
--- a/__tests__/helpers/apiService.test.ts
+++ b/__tests__/helpers/apiService.test.ts
@@ -100,6 +100,7 @@ describe('apiService', () => {
       (ScripMasterStore.getInstance as jest.Mock).mockReturnValue({
         getPostData: getPostDataMock,
         setPostData: setPostDataMock,
+        isExpired: jest.fn().mockReturnValue(false),
       });
       const mockScripMaster = [{ name: 'NIFTY' }];
       (api.get as jest.Mock).mockResolvedValue(mockScripMaster);
@@ -120,6 +121,7 @@ describe('apiService', () => {
         .mockReturnValue({ SCRIP_MASTER_JSON: mockScripMaster });
       (ScripMasterStore.getInstance as jest.Mock).mockReturnValue({
         getPostData: getPostDataMock,
+        isExpired: jest.fn().mockReturnValue(false),
       });
 
       const result = await fetchData();

--- a/__tests__/helpers/apiService/marketData.test.ts
+++ b/__tests__/helpers/apiService/marketData.test.ts
@@ -32,6 +32,7 @@ describe('ApiService - MarketData', () => {
     mockScripMasterStoreInstance = {
       getPostData: jest.fn().mockReturnValue({ SCRIP_MASTER_JSON: [] }),
       setPostData: jest.fn(),
+      isExpired: jest.fn().mockReturnValue(false),
     };
     (ScripMasterStore.getInstance as jest.Mock).mockReturnValue(
       mockScripMasterStoreInstance,

--- a/__tests__/store/scripMasterStore.test.ts
+++ b/__tests__/store/scripMasterStore.test.ts
@@ -26,4 +26,23 @@ describe('ScripMasterStore', () => {
     instance.setPostData({ SCRIP_MASTER_JSON: mockData });
     expect(instance.getPostData().SCRIP_MASTER_JSON).toEqual(mockData);
   });
+
+  it('should not be expired initially', () => {
+    const instance = ScripMasterStore.getInstance();
+    expect(instance.isExpired()).toBe(false);
+  });
+
+  it('should be expired if data is more than 24 hours old', () => {
+    const instance = ScripMasterStore.getInstance();
+    instance.setPostData({ SCRIP_MASTER_JSON: [] });
+
+    // Mock Date.now to be 25 hours in the future
+    const originalDateNow = Date.now;
+    Date.now = jest.fn(() => originalDateNow() + 25 * 60 * 60 * 1000);
+
+    expect(instance.isExpired()).toBe(true);
+
+    // Restore original Date.now
+    Date.now = originalDateNow;
+  });
 });

--- a/src/helpers/apiService/marketData.ts
+++ b/src/helpers/apiService/marketData.ts
@@ -24,8 +24,10 @@ import { getAuthHeaders } from './session';
  * @returns {Promise<scripMasterResponse[]>} A promise that resolves with the scrip master data.
  */
 export const fetchData = async (): Promise<scripMasterResponse[]> => {
-  const data = ScripMasterStore.getInstance().getPostData().SCRIP_MASTER_JSON;
-  if (data.length > 0) {
+  const store = ScripMasterStore.getInstance();
+  const data = store.getPostData().SCRIP_MASTER_JSON;
+
+  if (data.length > 0 && !store.isExpired()) {
     return data as scripMasterResponse[];
   } else {
     try {

--- a/src/store/scripMasterStore.ts
+++ b/src/store/scripMasterStore.ts
@@ -19,6 +19,12 @@ class ScripMasterStore {
    */
   private postData: ScripMasterStoreDataType;
   /**
+   * The timestamp when the data was last set.
+   * @private
+   * @type {number}
+   */
+  private lastSetTimestamp: number;
+  /**
    * The private constructor to create a new instance of the ScripMasterStore.
    * @private
    */
@@ -27,6 +33,7 @@ class ScripMasterStore {
     this.postData = {
       SCRIP_MASTER_JSON: [],
     };
+    this.lastSetTimestamp = 0;
   }
   /**
    * Gets the singleton instance of the ScripMasterStore.
@@ -45,6 +52,7 @@ class ScripMasterStore {
    */
   setPostData(data: ScripMasterStoreDataType) {
     this.postData = data;
+    this.lastSetTimestamp = Date.now();
   }
   /**
    * Gets the scrip master data.
@@ -52,6 +60,15 @@ class ScripMasterStore {
    */
   getPostData() {
     return this.postData;
+  }
+  /**
+   * Checks if the stored data is expired (more than 24 hours old).
+   * @returns {boolean} True if expired, false otherwise.
+   */
+  isExpired() {
+    if (this.lastSetTimestamp === 0) return true;
+    const twentyFourHoursInMs = 24 * 60 * 60 * 1000;
+    return Date.now() - this.lastSetTimestamp > twentyFourHoursInMs;
   }
 }
 


### PR DESCRIPTION
This PR introduces a 24-hour expiration policy for the Scrip Master JSON. Previously, once downloaded, it would stay in memory indefinitely. Now, the ScripMasterStore tracks a timestamp and etchData will force a redownload if the data is older than 24 hours.