### PR TITLE
fix: ensure environment variables are loaded before module imports

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,6 +1,4 @@
-import dotenv from 'dotenv';
-
-dotenv.config();
+import { logger } from '../helpers/logger';
 
 /**
  * Application configuration.
@@ -25,3 +23,14 @@ export const config = {
    */
   telegramChatId: process.env.TELEGRAM_CHAT_ID,
 };
+
+// Diagnostic logging
+if (!config.telegramBotToken || !config.telegramChatId) {
+  logger.warn(
+    `[ENV] Telegram configuration missing in process.env. TOKEN: ${config.telegramBotToken ? 'Present' : 'Missing'}, CHAT_ID: ${config.telegramChatId ? 'Present' : 'Missing'}`,
+  );
+} else {
+  logger.log(
+    `[ENV] Telegram configuration loaded. TOKEN: ${config.telegramBotToken.substring(0, 5)}..., CHAT_ID: ${config.telegramChatId}`,
+  );
+}

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,5 +1,3 @@
-import { logger } from '../helpers/logger';
-
 /**
  * Application configuration.
  */
@@ -26,11 +24,11 @@ export const config = {
 
 // Diagnostic logging
 if (!config.telegramBotToken || !config.telegramChatId) {
-  logger.warn(
+  console.warn(
     `[ENV] Telegram configuration missing in process.env. TOKEN: ${config.telegramBotToken ? 'Present' : 'Missing'}, CHAT_ID: ${config.telegramChatId ? 'Present' : 'Missing'}`,
   );
 } else {
-  logger.log(
+  console.log(
     `[ENV] Telegram configuration loaded. TOKEN: ${config.telegramBotToken.substring(0, 5)}..., CHAT_ID: ${config.telegramChatId}`,
   );
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,3 +1,6 @@
+import dotenv from 'dotenv';
+dotenv.config();
+
 import { Server, createServer } from 'http';
 import { Socket } from 'net';
 import app from './app';


### PR DESCRIPTION
This PR fixes an issue where Telegram environment variables were not being loaded correctly upon application startup.

### Changes:
- **Early Initialization:** Moved `dotenv.config()` to the absolute top of `src/server.ts` (before any other imports) to ensure all subsequent modules have access to `process.env`.
- **Diagnostic Logging:** Added logging in `src/config/env.ts` to confirm whether Telegram tokens are being loaded from the environment. This will help debug issues on the server.

Verified with unit tests and project-wide checks (typecheck, lint, build).
