### PR TITLE
fix: harden environment variable loading

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,4 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-require-imports
+// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
 require('dotenv').config();
 
 /**

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,3 +1,6 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+require('dotenv').config();
+
 /**
  * Application configuration.
  */


### PR DESCRIPTION
This PR hardens the environment variable loading to prevent issues with module initialization order and import hoisting.

### Changes:
- Moved \dotenv.config()\ directly into \src/config/env.ts\ using a synchronous \equire\ call.
- This ensures that \process.env\ is fully populated before the \config\ object is exported, even if the module is imported indirectly via other modules.