### PR TITLE
fix(marketData): use strict index name match to prevent wrong index trades

### DIFF
--- a/src/helpers/apiService/marketData.ts
+++ b/src/helpers/apiService/marketData.ts
@@ -222,7 +222,7 @@ export const getScrip = async ({
       const _symbol: string = _get(scrip, 'symbol', '') || '';
       const _expiry: string = _get(scrip, 'expiry', '') || '';
       return (
-        (_scripName.includes(scriptName) || _scripName === scriptName) &&
+        _scripName === scriptName &&
         _get(scrip, 'exch_seg') === 'NFO' &&
         _get(scrip, 'instrumenttype') === 'OPTIDX' &&
         (strikePrice === undefined || _symbol.includes(strikePrice)) &&


### PR DESCRIPTION
Fixes the substring option matching bug in getScrip where 'FINNIFTY' matched 'NIFTY', causing wrong positions to be taken on Tuesdays. Uses strict index equality comparison instead.