### PR TITLE
feat(telegram): add /logs command to retrieve recent logs

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -24,12 +24,13 @@ The **smart-api** project is an intraday trading algorithm developed in Node.js,
 
 The application includes a Telegram bot listener for remote control and monitoring. Supported commands include:
 
-- `/kill`: Initiates an abrupt shutdown of the algorithm.
-- `/resume` / `/start`: Clears the kill switch and allows the algorithm to run.
-- `/status`: Returns the current running status and mode (Paper/Live).
-- `/paperon`: Enables Paper Trading mode.
-- `/paperoff`: Enables Live Trading mode.
-- `/logs`: Retrieves the last 20 lines of application logs (via PM2 or local log file).
+- \`kill\`: Initiates an abrupt shutdown of the algorithm.
+- \`resume\` / \`start\`: Clears the kill switch and allows the algorithm to run.
+- \`status\`: Returns the current running status and mode (Paper/Live).
+- \`paperon\`: Enables Paper Trading mode.
+- \`paperoff\`: Enables Live Trading mode.
+- \`logs\`: Retrieves the last 20 lines of application logs (via PM2 or local log file).
+
 
 # Building and Running
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -74,6 +74,7 @@ npm run dev
 
 ### Coding Style & Linting
 
+- **Formatting Preference:** Use backticks (backquotes) `` ` `` instead of forward `/` or backward `\` slashes for commands, file paths, and code snippets in documentation and PRs to ensure better Markdown rendering.
 - **Linting:** ESLint is used for code quality.
 - **Formatting:** Prettier is used for consistent code styling.
 - **Configuration:** Managed via `eslint.config.mjs`, `.babelrc`, and settings in `package.json`.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -31,7 +31,6 @@ The application includes a Telegram bot listener for remote control and monitori
 - \`paperoff\`: Enables Live Trading mode.
 - \`logs\`: Retrieves the last 20 lines of application logs (via PM2 or local log file).
 
-
 # Building and Running
 
 ### Development

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -20,6 +20,17 @@ The **smart-api** project is an intraday trading algorithm developed in Node.js,
 - **Middlewares:** Custom middlewares like `errorHandler.ts` in `src/middlewares/`.
 - **Helpers:** Utility functions and constants in `src/helpers/`.
 
+### Telegram Bot Commands
+
+The application includes a Telegram bot listener for remote control and monitoring. Supported commands include:
+
+- `/kill`: Initiates an abrupt shutdown of the algorithm.
+- `/resume` / `/start`: Clears the kill switch and allows the algorithm to run.
+- `/status`: Returns the current running status and mode (Paper/Live).
+- `/paperon`: Enables Paper Trading mode.
+- `/paperoff`: Enables Live Trading mode.
+- `/logs`: Retrieves the last 20 lines of application logs (via PM2 or local log file).
+
 # Building and Running
 
 ### Development

--- a/__tests__/helpers/telegram.test.ts
+++ b/__tests__/helpers/telegram.test.ts
@@ -11,6 +11,8 @@ import {
 } from '../../src/helpers/killSwitch';
 import { logger } from '../../src/helpers/logger';
 import { setPaperMode } from '../../src/helpers/paperTrade';
+import { exec } from 'child_process';
+import fs from 'fs';
 
 jest.mock('../../src/helpers/api');
 jest.mock('../../src/config/env', () => ({
@@ -23,6 +25,14 @@ jest.mock('../../src/config/env', () => ({
 jest.mock('../../src/helpers/killSwitch');
 jest.mock('../../src/helpers/logger');
 jest.mock('../../src/helpers/paperTrade');
+jest.mock('child_process', () => ({
+  exec: jest.fn(),
+}));
+jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
+  existsSync: jest.fn(),
+  readFileSync: jest.fn(),
+}));
 
 describe('telegram helper', () => {
   beforeEach(() => {
@@ -288,6 +298,139 @@ describe('telegram helper', () => {
       await Promise.resolve(); // sendMessage
 
       expect(setPaperMode).toHaveBeenCalledWith(false);
+    });
+
+    it('should process /logs command (PM2 success)', async () => {
+      const pm2Logs = 'PM2 log output';
+      (exec as unknown as jest.Mock).mockImplementation((cmd, callback) => {
+        callback(null, { stdout: pm2Logs });
+      });
+
+      (get as jest.Mock)
+        .mockResolvedValueOnce({ ok: true, result: [] }) // init
+        .mockResolvedValueOnce({
+          ok: true,
+          result: [
+            {
+              update_id: 101,
+              message: { chat: { id: 'test_chat_id' }, text: '/logs' },
+            },
+          ],
+        })
+        .mockResolvedValueOnce({ ok: true }); // sendMessage
+
+      await startTelegramBotListener();
+      await Promise.resolve(); // init
+      await Promise.resolve(); // poll
+      await Promise.resolve(); // fetchLogs
+      await Promise.resolve(); // sendMessage
+
+      expect(get).toHaveBeenCalledWith(
+        expect.stringContaining(
+          encodeURIComponent('```\n' + pm2Logs + '\n```'),
+        ),
+        {},
+      );
+    });
+
+    it('should process /logs command (PM2 fail, fallback to file)', async () => {
+      (exec as unknown as jest.Mock).mockImplementation((cmd, callback) => {
+        callback(new Error('PM2 not found'), { stdout: '' });
+      });
+      (fs.existsSync as jest.Mock).mockReturnValue(true);
+      (fs.readFileSync as jest.Mock).mockReturnValue(
+        'file log output line 1\nline 2',
+      );
+
+      (get as jest.Mock)
+        .mockResolvedValueOnce({ ok: true, result: [] }) // init
+        .mockResolvedValueOnce({
+          ok: true,
+          result: [
+            {
+              update_id: 101,
+              message: { chat: { id: 'test_chat_id' }, text: '/logs' },
+            },
+          ],
+        })
+        .mockResolvedValueOnce({ ok: true }); // sendMessage
+
+      await startTelegramBotListener();
+      await Promise.resolve(); // init
+      await Promise.resolve(); // poll
+      await Promise.resolve(); // fetchLogs
+      await Promise.resolve(); // sendMessage
+
+      expect(get).toHaveBeenCalledWith(
+        expect.stringContaining(
+          encodeURIComponent('```\nfile log output line 1\nline 2\n```'),
+        ),
+        {},
+      );
+    });
+
+    it('should truncate logs if they are too long', async () => {
+      const longLogs = 'A'.repeat(5000);
+      (exec as unknown as jest.Mock).mockImplementation((cmd, callback) => {
+        callback(null, { stdout: longLogs });
+      });
+
+      (get as jest.Mock)
+        .mockResolvedValueOnce({ ok: true, result: [] })
+        .mockResolvedValueOnce({
+          ok: true,
+          result: [
+            {
+              update_id: 101,
+              message: { chat: { id: 'test_chat_id' }, text: '/logs' },
+            },
+          ],
+        })
+        .mockResolvedValueOnce({ ok: true });
+
+      await startTelegramBotListener();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const callWithSendMessage = (get as jest.Mock).mock.calls.find(call =>
+        call[0].includes('sendMessage'),
+      );
+      const url = decodeURIComponent(callWithSendMessage[0]);
+      expect(url).toContain('...');
+      expect(url.length).toBeLessThan(4200);
+    });
+
+    it('should return "No logs found." if output is empty', async () => {
+      (exec as unknown as jest.Mock).mockImplementation((cmd, callback) => {
+        callback(null, { stdout: '' });
+      });
+      (fs.existsSync as jest.Mock).mockReturnValue(false);
+
+      (get as jest.Mock)
+        .mockResolvedValueOnce({ ok: true, result: [] })
+        .mockResolvedValueOnce({
+          ok: true,
+          result: [
+            {
+              update_id: 101,
+              message: { chat: { id: 'test_chat_id' }, text: '/logs' },
+            },
+          ],
+        })
+        .mockResolvedValueOnce({ ok: true });
+
+      await startTelegramBotListener();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(get).toHaveBeenCalledWith(
+        expect.stringContaining(encodeURIComponent('No logs found.')),
+        {},
+      );
     });
 
     it('should handle poll error gracefully', async () => {

--- a/src/helpers/telegram.ts
+++ b/src/helpers/telegram.ts
@@ -1,3 +1,7 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import fs from 'fs';
+import path from 'path';
 import { config } from '../config/env';
 import { get } from './api';
 import {
@@ -7,6 +11,45 @@ import {
 } from './killSwitch';
 import { logger } from './logger';
 import { isPaperMode, setPaperMode } from './paperTrade';
+
+const execAsync = promisify(exec);
+const MAX_TELEGRAM_MESSAGE_LENGTH = 4000;
+
+/**
+ * Fetches the last 20 lines of logs.
+ * Tries PM2 first, then falls back to the local log file.
+ */
+const fetchLogs = async (): Promise<string> => {
+  let logOutput = '';
+  try {
+    const { stdout } = await execAsync(
+      'pm2 logs smart-api --lines 20 --nostream',
+    );
+    logOutput = stdout;
+  } catch (error) {
+    // Fallback to local log file
+    const logFilePath = path.join(process.cwd(), 'logs', 'app.log');
+    if (fs.existsSync(logFilePath)) {
+      try {
+        const logs = fs.readFileSync(logFilePath, 'utf8');
+        const lines = logs.trim().split('\n');
+        logOutput = lines.slice(-20).join('\n');
+      } catch (readError) {
+        logOutput = 'Error reading local log file.';
+      }
+    } else {
+      logOutput = 'PM2 logs failed and local log file not found.';
+    }
+  }
+
+  if (!logOutput || logOutput.trim() === '') return 'No logs found.';
+
+  if (logOutput.length > MAX_TELEGRAM_MESSAGE_LENGTH) {
+    logOutput = '...' + logOutput.slice(-MAX_TELEGRAM_MESSAGE_LENGTH);
+  }
+
+  return `\`\`\`\n${logOutput}\n\`\`\``;
+};
 
 /**
  * Sends a message to a Telegram chat.
@@ -138,6 +181,9 @@ export const startTelegramBotListener = async () => {
           } else if (text === '/paperoff') {
             setPaperMode(false);
             await sendTelegramMessage('💰 *Live Trading Mode ENABLED.*');
+          } else if (text === '/logs') {
+            const logs = await fetchLogs();
+            await sendTelegramMessage(logs);
           }
         }
       }


### PR DESCRIPTION
This PR introduces a new `logs` command to the Telegram bot, allowing users to retrieve the last 20 lines of application logs directly in the chat.

### Key Changes:
- **Telegram Command**: Added `logs` command handler.
- **Log Fetching**: Implements a dual-fetch strategy:
  - Primary: Uses `pm2 logs` for production environments.
  - Fallback: Reads from `logs/app.log` for local/development environments.
- **Message Handling**: Includes truncation logic to stay within Telegram message limits and formatting in Markdown code blocks.
- **Testing**: Added comprehensive tests in `__tests__/helpers/telegram.test.ts` for all scenarios.

Verified with full suite (lint, typecheck, tests).