### PR TITLE
fix: resolve duplicate trades in paper mode

### DIFF
--- a/src/helpers/paperTrade.ts
+++ b/src/helpers/paperTrade.ts
@@ -184,6 +184,17 @@ export const mockOrderPlacement = async (
     } else {
       // Create new position
       const postData = OrderStore.getInstance().getPostData();
+
+      // Extract strikeprice and optiontype from tradingsymbol (e.g. NIFTY09JUN2623200CE)
+      let strikeprice = '0';
+      let optiontype: 'CE' | 'PE' = 'CE';
+      const symbolRegex = /^([A-Z]+)(\d{2}[A-Z]{3}\d{2})(\d+\.?\d*)([CP]E)$/;
+      const match = params.tradingsymbol.match(symbolRegex);
+      if (match) {
+        strikeprice = match[3];
+        optiontype = match[4] as 'CE' | 'PE';
+      }
+
       const newPos: Partial<Position> = {
         symboltoken: params.symboltoken,
         tradingsymbol: params.tradingsymbol,
@@ -192,6 +203,8 @@ export const mockOrderPlacement = async (
           (params.tradingsymbol.includes('BANKNIFTY') ? 'BANKNIFTY' : 'NIFTY'),
         expirydate: postData.EXPIRYDATE,
         exchange: 'NFO',
+        strikeprice,
+        optiontype,
         netqty: qty.toString(),
         buyqty: params.transactionType === 'BUY' ? quantity.toString() : '0',
         sellqty: params.transactionType === 'SELL' ? quantity.toString() : '0',


### PR DESCRIPTION
## Problem
In Paper Trading mode, the algorithm was executing duplicate trades every 5 minutes. This was caused by the mock position object missing strikeprice and optiontype fields. The position detection logic (checkStrike and areBothOptionTypesPresentForStrike) relies on these fields to filter and identify active trades. Without them, it would mistakenly believe no trades existed for the current ATM strike and trigger a new straddle.

## Solution
- Updated mockOrderPlacement in src/helpers/paperTrade.ts to extract strikeprice and optiontype from the 	tradingsymbol using a robust regex.
- Ensured these fields are correctly populated when a new paper position is created.

## Verification
- Analyzed app.log from the server to confirm the duplicate execution sequence.
- Verified the fix by running the full test suite (215 tests passed).