### PR TITLE
fix: resolve redundant stop loss placement in paper mode

### DIFF
--- a/src/helpers/paperTrade.ts
+++ b/src/helpers/paperTrade.ts
@@ -94,11 +94,23 @@ export const mockOrderPlacement = async (
   const paperId = `PAPER-${Date.now()}`;
   logger.info(`[PAPER] Mocking order: ${paperId} for ${params.tradingsymbol}`);
 
+  // Extract strikeprice and optiontype from tradingsymbol (e.g. NIFTY09JUN2623200CE)
+  let strikeprice = '0';
+  let optiontype: 'CE' | 'PE' = 'CE';
+  const symbolRegex = /^([A-Z]+)(\d{2}[A-Z]{3}\d{2})(\d+\.?\d*)([CP]E)$/;
+  const match = params.tradingsymbol.match(symbolRegex);
+  if (match) {
+    strikeprice = match[3];
+    optiontype = match[4] as 'CE' | 'PE';
+  }
+
   if (params.variety === 'STOPLOSS' || params.ordertype.includes('STOPLOSS')) {
     // Store as pending order
     const orders = getPaperOrders();
     orders.push({
       ...params,
+      strikeprice,
+      optiontype,
       orderid: paperId,
       status: 'Pending',
       orderstatus: 'Pending',
@@ -184,16 +196,6 @@ export const mockOrderPlacement = async (
     } else {
       // Create new position
       const postData = OrderStore.getInstance().getPostData();
-
-      // Extract strikeprice and optiontype from tradingsymbol (e.g. NIFTY09JUN2623200CE)
-      let strikeprice = '0';
-      let optiontype: 'CE' | 'PE' = 'CE';
-      const symbolRegex = /^([A-Z]+)(\d{2}[A-Z]{3}\d{2})(\d+\.?\d*)([CP]E)$/;
-      const match = params.tradingsymbol.match(symbolRegex);
-      if (match) {
-        strikeprice = match[3];
-        optiontype = match[4] as 'CE' | 'PE';
-      }
 
       const newPos: Partial<Position> = {
         symboltoken: params.symboltoken,


### PR DESCRIPTION
## Problem
In Paper Mode, Stop Loss orders were being placed every 5 minutes even if they already existed. This was because the mock order objects in paper-orders.json were missing the strikeprice and optiontype fields, causing the deduplication check hasStopLossOrderForPosition to fail.

## Solution
- Updated mockOrderPlacement in src/helpers/paperTrade.ts to extract strikeprice and optiontype for **all** mocked orders (both pending SL orders and market orders).
- This ensures the detection logic can correctly identify existing SL orders.

## Verification
- Confirmed the logic failure from logs (Algo finding 4 pending orders but reporting 0 found for existing positions).
- Verified fix with existing test suite.