### PR TITLE
fix: correct position api endpoint typo and add enhanced logging

### DIFF
--- a/src/helpers/apiService/positions.ts
+++ b/src/helpers/apiService/positions.ts
@@ -92,11 +92,16 @@ export const getPositions = async (
   const headers = await getAuthHeaders();
 
   try {
-    const responseJson = await get(
-      'https://apiconnect.angelbroking.com/rest/secure/angelbroking/order/v1/getPositions',
-      headers,
-    );
-    const positions = _get(responseJson, 'data', []) as Position[];
+    const responseJson = await get(GET_POSITIONS, headers);
+    const positions = _get(responseJson, 'data', null);
+
+    if (positions === null) {
+      logger.warn(
+        `${ALGO}: getPositions — 'data' field missing in response. Full response:`,
+        responseJson,
+      );
+      return [];
+    }
 
     if (Array.isArray(positions)) {
       logger.log(

--- a/src/helpers/apiService/positions.ts
+++ b/src/helpers/apiService/positions.ts
@@ -14,6 +14,7 @@ import {
   TRANSACTION_TYPE_BUY,
   TRANSACTION_TYPE_SELL,
   ME,
+  GET_POSITIONS,
 } from '../constants';
 import { Position, ISmartApiData, CheckPosition } from '../../app.interface';
 import {


### PR DESCRIPTION
This PR fixes a critical bug where the algorithm failed to detect existing positions, leading to duplicate order placement every 5 minutes.

Key Changes:
1. **Endpoint Typo Fix:** Updated `src/helpers/apiService/positions.ts` to use the correct singular `getPosition` endpoint (via the `GET_POSITIONS` constant). It was previously using a plural version which returned empty data.
2. **Enhanced Logging:** Added robust logging for the full raw response if the position data is missing, facilitating easier debugging of broker-side API changes.
3. **Code Consistency:** Removed hardcoded URLs in favor of centralized constants.

Target Branch: `development`