### PR TITLE
ci: resolve pnpm aborted removal error due to no TTY

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,16 +17,20 @@ jobs:
           key: ${{ secrets.ORACLE_SSH_KEY }}
           script: |
             # Check if directory exists, if not clone it
-            if [ ! -d "~/smart-api" ]; then
-              git clone https://github.com/kunalrbhatia/smart-api.git ~/smart-api
+            if [ ! -d "$HOME/smart-api" ]; then
+              git clone https://github.com/kunalrbhatia/smart-api.git "$HOME/smart-api"
             fi
             
-            cd ~/smart-api
+            cd "$HOME/smart-api"
             git fetch origin development
             git reset --hard origin/development
             
             # Ensure pnpm is installed and up-to-date
             sudo npm install -g pnpm@latest
+            
+            # Fix: Set CI=true to avoid TTY issues when pnpm needs to remove node_modules
+            export CI=true
+            pnpm config set confirmModulesPurge false
             
             pnpm install --no-frozen-lockfile
             pnpm build


### PR DESCRIPTION
This PR fixes the [ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY] error encountered during deployment on Oracle Cloud.

### Key Changes:
1. **CI Environment Variable:** Added export CI=true to the deployment script to tell pnpm it is running in a non-interactive environment.
2. **Module Purge Configuration:** Set confirmModulesPurge to false to prevent pnpm from asking for confirmation when it needs to clear node_modules.
3. **Path Robustness:** Switched from ~ to $HOME and improved directory existence checks to avoid redundant git clone warnings.

Target Branch: development