### PR TITLE
ci: inject slack and telegram secrets into deployment environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,10 @@ jobs:
             echo "CLIENT_TOTP_PIN=${{ secrets.CLIENT_TOTP_PIN }}" >> .env
             echo "TELEGRAM_BOT_TOKEN=${{ secrets.TELEGRAM_BOT_TOKEN }}" >> .env
             echo "TELEGRAM_CHAT_ID=${{ secrets.TELEGRAM_CHAT_ID }}" >> .env
+            echo "SLACK_WEBHOOK_URL=${{ secrets.SLACK_WEBHOOK_URL }}" >> .env
+            echo "USE_SLACK=${{ secrets.USE_SLACK }}" >> .env
+            echo "USE_TELEGRAM=${{ secrets.USE_TELEGRAM }}" >> .env
+            echo "SLACK_SIGNING_SECRET=${{ secrets.SLACK_SIGNING_SECRET }}" >> .env
 
             # Restart with PM2
             pm2 restart ecosystem.config.cjs || pm2 start ecosystem.config.cjs


### PR DESCRIPTION
### Description
This PR updates the deployment step in the CI/CD pipeline to inject the newly required Slack and Telegram environment variables into the production \.env\ file.

### Changes
- Updated \.github/workflows/ci.yml\ to write \SLACK_WEBHOOK_URL\, \USE_SLACK\, \USE_TELEGRAM\, and \SLACK_SIGNING_SECRET\ from GitHub secrets to the deployed \.env\ file.

### Verification
- Manual review of the workflow yaml syntax.