### PR TITLE
fix: use raw body for slack signature verification

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -13,7 +13,14 @@ import { logger } from './helpers/logger';
 const app: Application = express();
 
 app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: true }));
+app.use(
+  bodyParser.urlencoded({
+    extended: true,
+    verify: (req: any, res, buf) => {
+      req.rawBody = buf.toString();
+    },
+  }),
+);
 app.use(cors());
 
 // Request logging middleware

--- a/src/middlewares/slackVerify.ts
+++ b/src/middlewares/slackVerify.ts
@@ -33,13 +33,9 @@ export const verifySlackSignature = (
     return res.status(401).send('Unauthorized');
   }
 
-  // Re-constructing url-encoded body from req.body
-
-  const sigBasestring = `v0:${timestamp}:${Object.keys(req.body)
-    .map(
-      key => `${encodeURIComponent(key)}=${encodeURIComponent(req.body[key])}`,
-    )
-    .join('&')}`;
+  // Use the raw body captured by bodyParser if available
+  const rawBody = (req as any).rawBody || '';
+  const sigBasestring = `v0:${timestamp}:${rawBody}`;
 
   const hmac = crypto
     .createHmac('sha256', slackSigningSecret)


### PR DESCRIPTION
### Description
Fixes the `dispatch_unknown_error` issue from Slack by capturing the raw request body during parsing.

### Changes
- Updated `src/app.ts` to attach `req.rawBody` in `bodyParser.urlencoded`.
- Updated `src/middlewares/slackVerify.ts` to use `req.rawBody` directly instead of attempting to manually reconstruct the URL-encoded string, which is prone to encoding discrepancies.

### Verification
- Checked locally that `pnpm verify` passes.