### PR TITLE
feat: implement additional slack slash commands

### DIFF
--- a/src/helpers/telegram.ts
+++ b/src/helpers/telegram.ts
@@ -30,7 +30,7 @@ const isTelegramPaused = (): boolean => {
  * Fetches the last 20 lines of logs.
  * Tries PM2 first, then falls back to the local log file.
  */
-const fetchLogs = async (): Promise<string> => {
+export const fetchLogs = async (): Promise<string> => {
   let logOutput = '';
   try {
     const { stdout } = await execAsync(

--- a/src/routes/api.routes.ts
+++ b/src/routes/api.routes.ts
@@ -24,9 +24,17 @@ import {
 import { ALGO } from '../helpers/constants';
 import { delay, INDICES } from 'krb-smart-api-module';
 import moment from 'moment-timezone';
-import { isKillSwitchActive } from '../helpers/killSwitch';
-import { isPaperMode } from '../helpers/paperTrade';
+import {
+  isKillSwitchActive,
+  setKillSwitch,
+  clearKillSwitch,
+} from '../helpers/killSwitch';
+import { isPaperMode, setPaperMode } from '../helpers/paperTrade';
 import { verifySlackSignature } from '../middlewares/slackVerify';
+import { fetchLogs } from '../helpers/telegram';
+import { get } from '../helpers/api';
+import { config } from '../config/env';
+
 interface IndexData {
   exchange: string;
   tradingsymbol: string;
@@ -444,8 +452,9 @@ router.post(
   verifySlackSignature,
   async (req: Request, res: Response) => {
     const { command } = req.body;
+    const cmd = command ? command.toLowerCase() : '';
 
-    if (command === '/check' || command === '/status') {
+    if (cmd === '/check' || cmd === '/status') {
       const status = isKillSwitchActive()
         ? '🛑 *Stopped (Kill Switch Active)*'
         : '✅ *Running*';
@@ -454,6 +463,50 @@ router.post(
       return res.json({
         response_type: 'ephemeral',
         text: `${status}. Monitoring active.\nMode: ${mode}`,
+      });
+    }
+
+    if (cmd === '/kill') {
+      setKillSwitch();
+      const port = config.port || 8080;
+      // Trigger the server's kill route locally without waiting
+      get(`http://localhost:${port}/kill`, {}).catch(() => {});
+
+      return res.json({
+        response_type: 'in_channel', // Broadcast the kill signal to the channel
+        text: '🛑 *Kill Signal Received.* Initiating abrupt shutdown...',
+      });
+    }
+
+    if (cmd === '/resume' || cmd === '/start') {
+      clearKillSwitch();
+      return res.json({
+        response_type: 'in_channel',
+        text: '🚀 *Kill Switch Cleared.* Algo is now allowed to run.',
+      });
+    }
+
+    if (cmd === '/paperon') {
+      setPaperMode(true);
+      return res.json({
+        response_type: 'in_channel',
+        text: '📝 *Paper Trading Mode ENABLED.*',
+      });
+    }
+
+    if (cmd === '/paperoff') {
+      setPaperMode(false);
+      return res.json({
+        response_type: 'in_channel',
+        text: '💰 *Live Trading Mode ENABLED.*',
+      });
+    }
+
+    if (cmd === '/logs') {
+      const logs = await fetchLogs();
+      return res.json({
+        response_type: 'ephemeral',
+        text: `\`\`\`${logs}\`\`\``,
       });
     }
 


### PR DESCRIPTION
### Description
Implements the remaining control commands for the Slack slash command listener, bringing feature parity with the Telegram bot.

### Changes
- Updated `src/routes/api.routes.ts` to support `/kill`, `/resume`, `/start`, `/paperon`, `/paperoff`, and `/logs` from Slack.
- Exported `fetchLogs` from `src/helpers/telegram.ts` to allow reuse in the Slack routes.

### Verification
- `pnpm verify` passed successfully (typechecks and tests).