### PR TITLE
fix: match on tradingsymbol only in hasStopLossOrderForPosition

### DIFF
--- a/src/helpers/apiService/orders.ts
+++ b/src/helpers/apiService/orders.ts
@@ -259,14 +259,10 @@ export const hasStopLossOrderForPosition = (
   pendingOrders: Record<string, unknown>[],
 ): boolean => {
   const tradingSymbol = position.tradingsymbol;
-  const optionType = position.optiontype;
-  const strikePrice = position.strikeprice;
 
   return pendingOrders.some(
     (order: Record<string, unknown>) =>
-      _get(order, 'tradingsymbol', '') === tradingSymbol &&
-      _get(order, 'optiontype', '') === optionType &&
-      _get(order, 'strikeprice', '') === strikePrice,
+      _get(order, 'tradingsymbol', '') === tradingSymbol,
   );
 };
 


### PR DESCRIPTION
### Description

Fixes a critical bug where the intraday algo repeatedly places stoploss orders every 5 minutes because it fails to recognize that they already exist.

### Changes

- Simplified `hasStopLossOrderForPosition` in `src/helpers/apiService/orders.ts` to check only the `tradingsymbol` of the position against the pending orders.
- Since the Angel Broking API order book does not return `optiontype` and `strikeprice` fields in the order book, the previous check always failed on live orders.

### Verification

- Local format check, eslint, typecheck, and tests passed cleanly.
- Verified that all unit tests in the suite pass (221 tests, 21 test suites).
