### PR TITLE
fix(slack): resolve shutdown circular dependency and use .kill state file

### DIFF
--- a/__tests__/helpers/killSwitch.test.ts
+++ b/__tests__/helpers/killSwitch.test.ts
@@ -15,10 +15,10 @@ describe('killSwitch helper', () => {
   });
 
   describe('setKillSwitch', () => {
-    it('should create the .killswitch file successfully', () => {
+    it('should create the .kill file successfully', () => {
       setKillSwitch();
       expect(fs.writeFileSync).toHaveBeenCalledWith(
-        expect.stringContaining('.killswitch'),
+        expect.stringContaining('.kill'),
         expect.any(String),
       );
       expect(logger.log).toHaveBeenCalledWith(
@@ -39,7 +39,7 @@ describe('killSwitch helper', () => {
   });
 
   describe('clearKillSwitch', () => {
-    it('should remove the .killswitch file if it exists', () => {
+    it('should remove the .kill file if it exists', () => {
       (fs.existsSync as jest.Mock).mockReturnValue(true);
       clearKillSwitch();
       expect(fs.unlinkSync).toHaveBeenCalled();
@@ -48,7 +48,7 @@ describe('killSwitch helper', () => {
       );
     });
 
-    it('should do nothing if the .killswitch file does not exist', () => {
+    it('should do nothing if the .kill file does not exist', () => {
       (fs.existsSync as jest.Mock).mockReturnValue(false);
       clearKillSwitch();
       expect(fs.unlinkSync).not.toHaveBeenCalled();

--- a/__tests__/helpers/shutdownEmitter.test.ts
+++ b/__tests__/helpers/shutdownEmitter.test.ts
@@ -1,0 +1,19 @@
+import { shutdownEmitter } from '../../src/helpers/shutdownEmitter';
+import { EventEmitter } from 'events';
+
+describe('shutdownEmitter', () => {
+  it('should be an instance of EventEmitter', () => {
+    expect(shutdownEmitter).toBeInstanceOf(EventEmitter);
+  });
+
+  it('should allow registering and triggering trigger events', () => {
+    const callback = jest.fn();
+    shutdownEmitter.on('trigger', callback);
+
+    shutdownEmitter.emit('trigger');
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    // Clean up
+    shutdownEmitter.off('trigger', callback);
+  });
+});

--- a/src/helpers/killSwitch.ts
+++ b/src/helpers/killSwitch.ts
@@ -2,12 +2,12 @@ import fs from 'fs';
 import path from 'path';
 import { logger } from './logger';
 
-const KILL_SWITCH_FILE = path.join(process.cwd(), '.killswitch');
+const KILL_SWITCH_FILE = path.join(process.cwd(), '.kill');
 
 export const setKillSwitch = (): void => {
   try {
     fs.writeFileSync(KILL_SWITCH_FILE, new Date().toISOString());
-    logger.log('🛑 Kill switch engaged: .killswitch file created.');
+    logger.log('🛑 Kill switch engaged: .kill file created.');
   } catch (error) {
     logger.error('Failed to set kill switch:', error);
   }
@@ -17,7 +17,7 @@ export const clearKillSwitch = (): void => {
   try {
     if (fs.existsSync(KILL_SWITCH_FILE)) {
       fs.unlinkSync(KILL_SWITCH_FILE);
-      logger.log('✅ Kill switch cleared: .killswitch file removed.');
+      logger.log('✅ Kill switch cleared: .kill file removed.');
     }
   } catch (error) {
     logger.error('Failed to clear kill switch:', error);

--- a/src/helpers/shutdownEmitter.ts
+++ b/src/helpers/shutdownEmitter.ts
@@ -1,0 +1,5 @@
+import { EventEmitter } from 'events';
+
+class ShutdownEmitter extends EventEmitter {}
+
+export const shutdownEmitter = new ShutdownEmitter();

--- a/src/helpers/telegram.ts
+++ b/src/helpers/telegram.ts
@@ -12,6 +12,7 @@ import {
 } from './killSwitch';
 import { logger } from './logger';
 import { isPaperMode, setPaperMode } from './paperTrade';
+import { shutdownEmitter } from './shutdownEmitter';
 
 const execAsync = promisify(exec);
 const MAX_TELEGRAM_MESSAGE_LENGTH = 4000;
@@ -184,9 +185,19 @@ export const startTelegramBotListener = async () => {
               // Ignore confirmation errors
             }
 
-            // Trigger the server's kill route locally
+            // Trigger the server's kill route locally (with catch to prevent crashing/blocking)
             const port = config.port || 8080;
-            await get(`http://localhost:${port}/kill`, {});
+            try {
+              await get(`http://localhost:${port}/kill`, {});
+            } catch (e) {
+              logger.error(
+                'Failed to call kill route via HTTP in Telegram listener:',
+                e,
+              );
+            }
+
+            // Directly trigger shutdown using emitter to be robust against localhost request failures
+            setTimeout(() => shutdownEmitter.emit('trigger'), 1000);
             return; // Stop polling
           } else if (text === '/resume' || text === '/start') {
             clearKillSwitch();

--- a/src/routes/api.routes.ts
+++ b/src/routes/api.routes.ts
@@ -34,6 +34,7 @@ import { verifySlackSignature } from '../middlewares/slackVerify';
 import { fetchLogs } from '../helpers/telegram';
 import { get } from '../helpers/api';
 import { config } from '../config/env';
+import { shutdownEmitter } from '../helpers/shutdownEmitter';
 
 interface IndexData {
   exchange: string;
@@ -471,6 +472,9 @@ router.post(
       const port = config.port || 8080;
       // Trigger the server's kill route locally without waiting
       get(`http://localhost:${port}/kill`, {}).catch(() => {});
+
+      // Directly trigger shutdown using emitter to be robust against localhost request failures
+      setTimeout(() => shutdownEmitter.emit('trigger'), 1000);
 
       return res.json({
         response_type: 'in_channel', // Broadcast the kill signal to the channel

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,7 +1,8 @@
 import { Router, Request, Response } from 'express';
 import algoRoutes from './algo.routes';
 import apiRouter from './api.routes';
-import { shutdown } from '../server';
+import { shutdownEmitter } from '../helpers/shutdownEmitter';
+
 const router = Router();
 
 /**
@@ -13,7 +14,7 @@ router.get('/', (req: Request, res: Response) => {
   res.json({ status: 'ok', lastUpdated: '2026-02-05, 13:59:00' });
 });
 router.get('/kill', (req: Request, res: Response) => {
-  setTimeout(shutdown, 1000);
+  setTimeout(() => shutdownEmitter.emit('trigger'), 1000);
   res.send("Execution of the 'Kill Algo' command has been initiated.");
 });
 router.use('/api', apiRouter);

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,6 +8,7 @@ import { config } from './config/env';
 import { ALGO } from './helpers/constants';
 import { startTelegramBotListener } from './helpers/telegram';
 import { logger } from './helpers/logger';
+import { shutdownEmitter } from './helpers/shutdownEmitter';
 
 /**
  * The HTTP server.
@@ -58,9 +59,4 @@ process.on('uncaughtException', err => {
 
 process.on('SIGTERM', shutdown);
 process.on('SIGINT', shutdown);
-
-// Optional /kill route (instead of process signal)
-app.get('/kill', (req, res) => {
-  setTimeout(shutdown, 1000);
-  res.send("Execution of the 'Kill Algo' command has been initiated.");
-});
+shutdownEmitter.on('trigger', shutdown);


### PR DESCRIPTION
### Description

Resolves the issue where the Slack `/kill` slash command (and Telegram `/kill` command) fails to shut down the server, and updates the kill switch state file from `.killswitch` to `.kill` to retain state via a physical file.

### Changes

- Created [shutdownEmitter.ts](file:///C:/Users/Kunal/Desktop/hobby-projects/smart-api/src/helpers/shutdownEmitter.ts) as a decoupled event emitter to signal application shutdown.
- Updated [server.ts](file:///C:/Users/Kunal/Desktop/hobby-projects/smart-api/src/server.ts) to register the `shutdown` listener on the new emitter and removed the duplicate, unreachable `/kill` route definition.
- Refactored [index.ts](file:///C:/Users/Kunal/Desktop/hobby-projects/smart-api/src/routes/index.ts) `/kill` endpoint to trigger shutdown via the emitter, resolving the circular dependency that previously made `shutdown` undefined.
- Refactored the Slack command handler in [api.routes.ts](file:///C:/Users/Kunal/Desktop/hobby-projects/smart-api/src/routes/api.routes.ts) and Telegram listener in [telegram.ts](file:///C:/Users/Kunal/Desktop/hobby-projects/smart-api/src/helpers/telegram.ts) to emit the shutdown trigger directly.
- Changed the kill switch state file from `.killswitch` to `.kill` in [killSwitch.ts](file:///C:/Users/Kunal/Desktop/hobby-projects/smart-api/src/helpers/killSwitch.ts).
- Added unit tests in [shutdownEmitter.test.ts](file:///C:/Users/Kunal/Desktop/hobby-projects/smart-api/__tests__/helpers/shutdownEmitter.test.ts) and updated tests in [killSwitch.test.ts](file:///C:/Users/Kunal/Desktop/hobby-projects/smart-api/__tests__/helpers/killSwitch.test.ts).

### Verification

- Run full verification suite: `pnpm run verify` passed successfully.
- Added unit tests for the new `shutdownEmitter` helper.
- Updated `killSwitch` tests to check for the `.kill` file name.
