### PR TITLE
fix(telegram): avoid calling telegram APIs when Slack is enabled

### DIFF
--- a/__tests__/helpers/telegram.test.ts
+++ b/__tests__/helpers/telegram.test.ts
@@ -20,6 +20,7 @@ jest.mock('../../src/config/env', () => ({
     telegramBotToken: 'test_token',
     telegramChatId: 'test_chat_id',
     port: 8080,
+    useTelegram: true,
   },
 }));
 jest.mock('../../src/helpers/killSwitch');

--- a/src/helpers/telegram.ts
+++ b/src/helpers/telegram.ts
@@ -70,6 +70,10 @@ export const fetchLogs = async (): Promise<string> => {
  * @returns {Promise<void>}
  */
 export const sendTelegramMessage = async (message: string): Promise<void> => {
+  if (!config.useTelegram) {
+    return;
+  }
+
   if (isTelegramPaused()) {
     logger.log(
       'Telegram: Message suppressed as services are paused until June 23, 2026.',
@@ -104,6 +108,13 @@ export const sendTelegramMessage = async (message: string): Promise<void> => {
  * Polls for new Telegram messages to handle remote commands.
  */
 export const startTelegramBotListener = async () => {
+  if (!config.useTelegram) {
+    logger.log(
+      '🤖 Telegram: Bot listener disabled as Telegram is not the active notification channel.',
+    );
+    return;
+  }
+
   if (isTelegramPaused()) {
     logger.log(
       '🤖 Telegram: Bot listener disabled as services are paused until June 23, 2026.',


### PR DESCRIPTION
### Description

Avoids calling Telegram APIs (polling updates or sending messages) when Slack notifications are configured (`config.useTelegram` is false).

### Changes

- Added `config.useTelegram` checks to the start of `sendTelegramMessage` and `startTelegramBotListener` in [telegram.ts](file:///C:/Users/Kunal/Desktop/hobby-projects/smart-api/src/helpers/telegram.ts).
- Updated mocked config in [telegram.test.ts](file:///C:/Users/Kunal/Desktop/hobby-projects/smart-api/__tests__/helpers/telegram.test.ts) to include `useTelegram: true` so unit tests for Telegram still run successfully.

### Verification

- Run full verification suite: `pnpm run verify` passed successfully.
