### PR TITLE
fix(stoploss): pass actual position quantity to doOrder inside placeStopLossOrder

### DIFF
--- a/src/helpers/apiService/orders.ts
+++ b/src/helpers/apiService/orders.ts
@@ -305,6 +305,7 @@ export const placeStopLossOrder = async (
         transactionType,
         symboltoken,
         lotSize,
+        quantity: Math.abs(netQty),
         variety: VARIETY_STOPLOSS,
         ordertype: 'STOPLOSS_LIMIT',
         price: limitPriceRounded,


### PR DESCRIPTION
### Description

Passes the actual open position's quantity (`quantity: Math.abs(netQty)`) to `doOrder` inside `placeStopLossOrder` rather than letting `doOrder` compute the quantity using default values (which logs `isHedge: undefined` and could compute incorrect quantities).

### Changes

- Updated the `doOrder` call inside `placeStopLossOrder` in [orders.ts](file:///C:/Users/Kunal/Desktop/hobby-projects/smart-api/src/helpers/apiService/orders.ts) to pass `quantity: Math.abs(netQty)`.

### Verification

- Run full verification suite: `pnpm run verify` passed successfully.
