### PR TITLE
fix(logging): comment out verbose raw orders in book logging

### DIFF
--- a/src/helpers/apiService/orders.ts
+++ b/src/helpers/apiService/orders.ts
@@ -205,17 +205,17 @@ export const getPendingOrders = async (): Promise<
     }
 
     if (Array.isArray(orders) && orders.length > 0) {
-      logger.log(
-        `${ALGO}: Raw orders in book:`,
-        orders.map((o: any) => ({
-          orderstatus: o.orderstatus,
-          status: o.status,
-          variety: o.variety,
-          ordertype: o.ordertype,
-          tradingsymbol: o.tradingsymbol,
-          text: o.text,
-        })),
-      );
+      // logger.log(
+      //   `${ALGO}: Raw orders in book:`,
+      //   orders.map((o: any) => ({
+      //     orderstatus: o.orderstatus,
+      //     status: o.status,
+      //     variety: o.variety,
+      //     ordertype: o.ordertype,
+      //     tradingsymbol: o.tradingsymbol,
+      //     text: o.text,
+      //   })),
+      // );
     } else {
       logger.log(`${ALGO}: Order book is empty! Response:`, responseJson);
     }


### PR DESCRIPTION
### Description

Comments out the verbose logging of raw orders in the order book (`Algo: Raw orders in book:`) to reduce log output clutter.

### Changes

- Commented out the `logger.log` call for `Raw orders in book:` inside `getPendingOrders` in [orders.ts](file:///C:/Users/Kunal/Desktop/hobby-projects/smart-api/src/helpers/apiService/orders.ts).

### Verification

- Run full verification suite: `pnpm run verify` passed successfully.
